### PR TITLE
Move build-custom.yml reusable workflow from chainlink repo as an action

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -1,0 +1,129 @@
+name: Build Image For Testing
+description: Common docker image builder for building chainlink test images
+inputs:
+  cl_repo:
+    required: true
+    description: The chainlink repository to use
+    default: ${{ github.repository }}
+  cl_ref:
+    required: false
+    description: The git ref from the chainlink repository to use
+    default: develop
+  push_tag:
+    required: true
+    description: The full docker tag to use for the push to ecr
+  dep_solana_sha:
+    required: false
+    description: chainlink-solana commit or branch
+  dep_terra_sha:
+    required: false
+    description: chainlink-terra commit or branch
+  dep_starknet_sha:
+    required: false
+    description: chainlink-starknet commit or branch
+  dep_atlas_sha:
+    required: false
+    description: atlas commit or branch
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_PRIVATE_GHA_PULL:
+    required: false
+    description: Token to pull private repos
+  GOPRIVATE:
+    required: false
+    description: private repos needed for go
+
+runs:
+  using: composite
+  steps:
+    - name: Checkout Chainlink repo
+      uses: actions/checkout@v2
+      with:
+        repository: ${{ inputs.cl_repo }}
+        ref: ${{ inputs.cl_ref }}
+    - uses: actions/setup-go@v3
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      with:
+        go-version-file: 'go.mod'
+    - name: Replace GHA URL
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+        QA_PRIVATE_GHA_PULL: ${{ inputs.QA_PRIVATE_GHA_PULL }}
+      run: git config --global url.https://${{ inputs.QA_PRIVATE_GHA_PULL }}@github.com/.insteadOf https://github.com/
+    - name: Replace Solana deps manual flow
+      if: ${{ inputs.dep_solana_sha }}
+      shell: bash
+      run: go get github.com/smartcontractkit/chainlink-solana@${{ inputs.dep_solana_sha }}
+    - name: Replace Terra deps manual flow
+      if: ${{ inputs.dep_terra_sha }}
+      shell: bash
+      run: go get github.com/smartcontractkit/chainlink-terra@${{ inputs.dep_terra_sha }}
+    - name: Replace StarkNet deps manual flow
+      if: ${{ inputs.dep_starknet_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/chainlink-starknet@${{ inputs.dep_starknet_sha }}
+    - name: Replace Atlas deps manual flow
+      if: ${{ inputs.dep_atlas_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
+    - name: Replace Solana deps workflow_call
+      if: ${{ inputs.dep_solana_sha }}
+      shell: bash
+      run: go get github.com/smartcontractkit/chainlink-solana@${{ inputs.dep_solana_sha }}
+    - name: Replace Terra deps workflow_call
+      if: ${{ inputs.dep_terra_sha }}
+      shell: bash
+      run: go get github.com/smartcontractkit/chainlink-terra@${{ inputs.dep_terra_sha }}
+    - name: Replace StarkNET deps workflow_call
+      if: ${{ inputs.dep_starknet_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/chainlink-starknet@${{ inputs.dep_starknet_sha }}
+    - name: Replace Atlas deps workflow_call
+      if: ${{ inputs.dep_atlas_sha }}
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
+    - name: Tidy
+      shell: bash
+      env:
+        GOPRIVATE: ${{ inputs.GOPRIVATE }}
+      run: go mod tidy
+    - name: Env vars
+      shell: bash
+      run: env
+    - name: Cat go.mod
+      shell: bash
+      run: cat go.mod
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 3600
+    - name: Login to Amazon ECR
+      id: login-ecr
+      uses: aws-actions/amazon-ecr-login@v1
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Build and Push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: core/chainlink.Dockerfile
+        # comma separated like: KEY1=VAL1,KEY2=VAL2,...
+        build-args: COMMIT_SHA=${{ github.sha }}
+        tags: ${{ inputs.push_tag }}
+        push: true


### PR DESCRIPTION
Changing this from a reusable workflow to an action during the migration opens us up to use more of the github `environment` settings that are being setup.