### PR TITLE
Remove duplicate `go gets`

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -76,26 +76,6 @@ runs:
       env:
         GOPRIVATE: ${{ inputs.GOPRIVATE }}
       run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
-    - name: Replace Solana deps workflow_call
-      if: ${{ inputs.dep_solana_sha }}
-      shell: bash
-      run: go get github.com/smartcontractkit/chainlink-solana@${{ inputs.dep_solana_sha }}
-    - name: Replace Terra deps workflow_call
-      if: ${{ inputs.dep_terra_sha }}
-      shell: bash
-      run: go get github.com/smartcontractkit/chainlink-terra@${{ inputs.dep_terra_sha }}
-    - name: Replace StarkNET deps workflow_call
-      if: ${{ inputs.dep_starknet_sha }}
-      shell: bash
-      env:
-        GOPRIVATE: ${{ inputs.GOPRIVATE }}
-      run: go get github.com/smartcontractkit/chainlink-starknet@${{ inputs.dep_starknet_sha }}
-    - name: Replace Atlas deps workflow_call
-      if: ${{ inputs.dep_atlas_sha }}
-      shell: bash
-      env:
-        GOPRIVATE: ${{ inputs.GOPRIVATE }}
-      run: go get github.com/smartcontractkit/atlas@${{ inputs.dep_atlas_sha }}
     - name: Tidy
       shell: bash
       env:


### PR DESCRIPTION
This was a remnant from when it was originally a workflow and had two different ways to call the workflow. As an action it just gets called as an action and thus is not needed.