### PR TITLE
Feature/sc 50114

### DIFF
--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -68,48 +68,14 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: smartcontractkit/tool-versions-to-env-action@v1.0.7
-      id: tool-versions
-    - name: Setup go ${{ steps.tool-versions.outputs.golang_version }}
-      uses: actions/setup-go@v3
+    - name: Setup environment
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@262922ac2eb083231b8992c92e66a54f6e166799
       with:
-        go-version: ${{ steps.tool-versions.outputs.golang_version }}
-    - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@v1
-      with:
-        aws-region: ${{ inputs.QA_AWS_REGION }}
-        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
-        role-duration-seconds: 3600
-    - name: Set Kubernetes Context
-      uses: azure/k8s-set-context@v2
-      with:
-        method: kubeconfig
-        kubeconfig: ${{ inputs.QA_KUBECONFIG }}
-    - name: Tool Versions
-      shell: bash
-      run: |
-        aws --version
-        aws sts get-caller-identity
-        kubectl version --short
-    - name: Cache Vendor Packages
-      uses: actions/cache@v3
-      id: cache-packages
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-          ~/go/bin
-        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-
-    - name: Download Go Vendor Packages
-      if: steps.cache-packages.outputs.cache-hit != 'true'
-      shell: bash
-      run: ${{ inputs.test_download_vendor_packages_command }}
-    - name: Install Ginkgo CLI
-      if: steps.cache-packages.outputs.cache-hit != 'true'
-      shell: bash
-      run: ${{ inputs.test_download_ginkgo_command }}
+        test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
+        test_download_ginkgo_command: ${{ inputs.test_download_ginkgo_command }}
+        QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
+        QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
       uses: actions/download-artifact@v3
@@ -120,16 +86,6 @@ runs:
       if: inputs.build_gauntlet_command != 'false'
       shell: bash
       run: ${{ inputs.build_gauntlet_command }}
-    - uses: azure/setup-helm@v3
-      with:
-        version: "v3.9.0"
-      id: install
-    - name: Add QA charts repo
-      shell: bash
-      run: helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
-    - name: Add Bitnami charts repo
-      shell: bash
-      run: helm repo add bitnami https://charts.bitnami.com/bitnami
     - name: Run Tests
       shell: bash
       env:

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -69,7 +69,7 @@ runs:
   using: composite
   steps:
     - name: Setup environment
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@262922ac2eb083231b8992c92e66a54f6e166799
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@main
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         test_download_ginkgo_command: ${{ inputs.test_download_ginkgo_command }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -1,0 +1,75 @@
+name: setup-run-tests-environment
+description: Common test env setup
+inputs:
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download
+  test_download_ginkgo_command:
+    required: false
+    description: The command to download Ginkgo
+    default: make install
+  QA_AWS_REGION:
+    required: true
+    description: The AWS region to use
+  QA_AWS_ROLE_TO_ASSUME:
+    required: true
+    description: The AWS role to assume
+  QA_KUBECONFIG:
+    required: true
+    description: The kubernetes configuration to use
+
+runs:
+  using: composite
+  steps:
+    - uses: smartcontractkit/tool-versions-to-env-action@v1.0.7
+      id: tool-versions
+    - name: Setup go ${{ steps.tool-versions.outputs.golang_version }}
+      uses: actions/setup-go@v3
+      with:
+        go-version: ${{ steps.tool-versions.outputs.golang_version }}
+    - name: Configure AWS Credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-region: ${{ inputs.QA_AWS_REGION }}
+        role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
+        role-duration-seconds: 3600
+    - name: Set Kubernetes Context
+      uses: azure/k8s-set-context@v2
+      with:
+        method: kubeconfig
+        kubeconfig: ${{ inputs.QA_KUBECONFIG }}
+    - name: Tool Versions
+      shell: bash
+      run: |
+        aws --version
+        aws sts get-caller-identity
+        kubectl version --short
+    - name: Cache Vendor Packages
+      uses: actions/cache@v3
+      id: cache-packages
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+          ~/go/bin
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Download Go Vendor Packages
+      if: steps.cache-packages.outputs.cache-hit != 'true'
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}
+    - name: Install Ginkgo CLI
+      if: steps.cache-packages.outputs.cache-hit != 'true'
+      shell: bash
+      run: ${{ inputs.test_download_ginkgo_command }}
+    - uses: azure/setup-helm@v3
+      with:
+        version: v${{ steps.tool-versions.outputs.helm_version }}
+    - name: Add QA charts repo
+      shell: bash
+      run: helm repo add chainlink-qa https://raw.githubusercontent.com/smartcontractkit/qa-charts/gh-pages/
+    - name: Add Bitnami charts repo
+      shell: bash
+      run: helm repo add bitnami https://charts.bitnami.com/bitnami


### PR DESCRIPTION
Split env setup for tests out to its own action so it can be ran to verify it isn't broken when tests do not need to be ran. Basically is the repo still setup to run tests correctly.
Other changes that will be made because of this include:
https://github.com/smartcontractkit/chainlink/pull/7209
https://github.com/smartcontractkit/chainlink-solana/pull/385
And because this repo is setup to only do squash merges there will be one more PR to set the version in the run-tests action to an existing commit.