### PR TITLE
Add cleanup action

### DIFF
--- a/chainlink-testing-framework/cleanup/action.yml
+++ b/chainlink-testing-framework/cleanup/action.yml
@@ -1,0 +1,23 @@
+name: chainlink-testing-framework-cleanup
+description: Common runner for cleaning up a namespace
+inputs:
+  triggered_by:
+    required: true
+    description: The triggered-by label for the k8s namespace
+    default: ci
+
+runs:
+  using: composite
+  steps:
+    - name: cleanup k8s cluster namespace
+      shell: bash
+      run: |
+        echo "looking for namespace"
+        NAMESPACE=$(kubectl get ns -l=triggered-by=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }} -o jsonpath='{.items[].metadata.name}' || echo "none")
+        if [ "none" != "$NAMESPACE" ]; then
+          echo "deleting namespace: ${NAMESPACE}"
+          kubectl delete ns "${NAMESPACE}"
+          echo "completed cleanup"
+        else
+          echo "no namespace found to cleanup"
+        fi

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -51,6 +51,10 @@ inputs:
   publish_test_results_commit:
     required: false
     description: Commit SHA to which test results are published. Only needed if the value of GITHUB_SHA does not work for you.
+  triggered_by:
+    required: true
+    description: The triggered-by label for the k8s namespace, required for cleanup
+    default: ci
   QA_AWS_REGION:
     required: true
     description: The AWS region to use
@@ -95,6 +99,7 @@ runs:
       run: |
         PATH=$PATH:$(go env GOPATH)/bin
         export PATH
+        export TEST_TRIGGERED_BY=${{ inputs.triggered_by }}-${{ github.event.pull_request.number || github.run_id }}
         ${{ inputs.test_command_to_run }}
     - name: Publish Test Results
       uses: EnricoMi/publish-unit-test-result-action@v1
@@ -111,3 +116,8 @@ runs:
       with:
         name: test-logs
         path: ${{ inputs.artifacts_location }}
+    - name: cleanup
+      if: always()
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@main
+      with:
+        triggered_by: ${{ inputs.triggered_by }}


### PR DESCRIPTION
Use cases:
1. If the tests spin up resources under the namespace but somehow die unexpectedly and gingko can't clean it up. The cleanup is added to the end of the run-tests to clean it up.
2. If we use gha concurrency to clean up jobs running on previous pr commits that are in progress they will not properly cleanup. We can add the cleanup at the workflow level to properly clean this up since they will not be hard cancelled like they are at the action level. The action level `if: always()` does not propagate through a cancel whereas a workflow level one does. It is a bit wonky.