### PR TITLE
Use go.mod for setup-go action instead of .tool-versions

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -45,7 +45,7 @@ runs:
   using: composite
   steps:
     - name: Checkout Chainlink repo
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}
@@ -54,6 +54,7 @@ runs:
         GOPRIVATE: ${{ inputs.GOPRIVATE }}
       with:
         go-version-file: "go.mod"
+        check-latest: true
     - name: Replace GHA URL
       shell: bash
       env:

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -55,6 +55,9 @@ inputs:
     required: true
     description: The triggered-by label for the k8s namespace, required for cleanup
     default: ci
+  go_mod_path:
+    required: false
+    description: The go.mod file path
   QA_AWS_REGION:
     required: true
     description: The AWS region to use
@@ -73,10 +76,11 @@ runs:
   using: composite
   steps:
     - name: Setup environment
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@d02e09ae912c5a89a48d1b7cf36f2f35d8f98c7b # v2.0.14
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.0.18
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         test_download_ginkgo_command: ${{ inputs.test_download_ginkgo_command }}
+        go_mod_path: ${{ inputs.go_mod_path }}
         QA_AWS_REGION: ${{ inputs.QA_AWS_REGION }}
         QA_AWS_ROLE_TO_ASSUME: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
@@ -118,6 +122,6 @@ runs:
         path: ${{ inputs.artifacts_location }}
     - name: cleanup
       if: always()
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@d02e09ae912c5a89a48d1b7cf36f2f35d8f98c7b # v2.0.14
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.0.18
       with:
         triggered_by: ${{ inputs.triggered_by }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -9,6 +9,10 @@ inputs:
     required: false
     description: The command to download Ginkgo
     default: make install
+  go_mod_path:
+    required: false
+    description: The go.mod file path
+    default: "go.mod"
   QA_AWS_REGION:
     required: true
     description: The AWS region to use
@@ -24,10 +28,11 @@ runs:
   steps:
     - uses: smartcontractkit/tool-versions-to-env-action@v1.0.7
       id: tool-versions
-    - name: Setup go ${{ steps.tool-versions.outputs.golang_version }}
+    - name: Setup Go
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ steps.tool-versions.outputs.golang_version }}
+        go-version-file: ${{ inputs.go_mod_path }}
+        check-latest: true
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
@@ -35,7 +40,7 @@ runs:
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600
     - name: Set Kubernetes Context
-      uses: azure/k8s-set-context@v2
+      uses: azure/k8s-set-context@v3
       with:
         method: kubeconfig
         kubeconfig: ${{ inputs.QA_KUBECONFIG }}


### PR DESCRIPTION
This means it can pull the latest patch version even when we haven't updated our .tool-versions yet. Basically less upkeep on our end.