### PR TITLE
Revert "remove cache from setup-go action"

### DIFF
--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -19,6 +19,10 @@ inputs:
   cache_key_id:
     required: true
     description: Cache go vendors unique id
+  no_cache:
+    required: false
+    description: Do not use a go cache
+    default: 'false'
 
 runs:
   using: composite
@@ -32,7 +36,7 @@ runs:
         cache: false
 
     - name: Cache Vendor Packages
-      if: inputs.cache_restore_only == 'false'
+      if: inputs.cache_restore_only == 'false' && inputs.no_cache == "false"
       uses: actions/cache@v3
       id: cache-packages
       with:
@@ -45,7 +49,7 @@ runs:
           ${{ runner.os }}-${{ inputs.cache_key_id }}-
 
     - name: Restore Cache Vendor Packages
-      if: inputs.cache_restore_only != 'false'
+      if: inputs.cache_restore_only != 'false' && inputs.no_cache == "false"
       uses: actions/cache/restore@v3
       id: restore-cache-packages
       with:

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -16,9 +16,9 @@ inputs:
     required: false
     description: Only restore the cache, set to true if you want to restore and save on cache hit miss
     default: 'false'
-  # cache_key_id:
-  #   required: true
-  #   description: Cache go vendors unique id
+  cache_key_id:
+    required: true
+    description: Cache go vendors unique id
 
 runs:
   using: composite
@@ -31,31 +31,31 @@ runs:
         check-latest: true
         cache: false
 
-    # - name: Cache Vendor Packages
-    #   if: inputs.cache_restore_only == 'false'
-    #   uses: actions/cache@v3
-    #   id: cache-packages
-    #   with:
-    #     path: |
-    #       ~/.cache/go-build
-    #       ~/go/pkg/mod
-    #       ~/go/bin
-    #     key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-${{ inputs.cache_key_id }}-
+    - name: Cache Vendor Packages
+      if: inputs.cache_restore_only == 'false'
+      uses: actions/cache@v3
+      id: cache-packages
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+          ~/go/bin
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-
 
-    # - name: Restore Cache Vendor Packages
-    #   if: inputs.cache_restore_only != 'false'
-    #   uses: actions/cache/restore@v3
-    #   id: restore-cache-packages
-    #   with:
-    #     path: |
-    #       ~/.cache/go-build
-    #       ~/go/pkg/mod
-    #       ~/go/bin
-    #     key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
-    #     restore-keys: |
-    #       ${{ runner.os }}-${{ inputs.cache_key_id }}-
+    - name: Restore Cache Vendor Packages
+      if: inputs.cache_restore_only != 'false'
+      uses: actions/cache/restore@v3
+      id: restore-cache-packages
+      with:
+        path: |
+          ~/.cache/go-build
+          ~/go/pkg/mod
+          ~/go/bin
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-
 
     - name: Tidy and check files
       shell: bash


### PR DESCRIPTION
Reverts smartcontractkit/chainlink-github-actions#122

This should have not been done. cache_restore_only can be used to not use a cache or we can add an input instead to choose to not cache. Removing the caching from this will cause lots of problems in other pipelines

In addition to the revert I also added the no_cache input to just avoid running the cache if that is needed.