### PR TITLE
[RE-1882] Bump semver-compare, go-test-results-parsing actions to node20

### DIFF
--- a/go/go-test-results-parsing/action.yml
+++ b/go/go-test-results-parsing/action.yml
@@ -12,5 +12,5 @@ inputs:
     description: 'The file you want to write the results out to, leave empty if you do not want to write to a file'
     required: false
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'

--- a/semver-compare/action.yml
+++ b/semver-compare/action.yml
@@ -14,5 +14,5 @@ outputs:
   result:
     description: 'Comparison result'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'


### PR DESCRIPTION
GH actions deprecating node16 as it's EOL - [github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/)

Bumping these two actions as they depend on it directly. Seems like other actions here are synced with a separate repository instead. Those are being handled in the "source" repositories.

---

[RE-1882](https://smartcontract-it.atlassian.net/browse/RE-1882)