### PR TITLE
Update check-dist workflow to use node20

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -27,10 +27,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Set Node.js 16.x
+      - name: Setup Node.js 20.x
         uses: actions/setup-node@v3.8.1
         with:
-          node-version: 16.x
+          node-version: 20.x
       - name: Rebuild the dist/ directory
         run: |
           cd ${{ matrix.app.directory }}


### PR DESCRIPTION
Tested all actions locally with node `20.8.1`.  This workflow is ran as part of pull requests, so it should be validated there as well.