### PR TITLE
[RE-2021] bump action references

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -122,7 +122,7 @@ runs:
     - name: Login to Amazon ECR
       if: steps.push.outputs.push == 'true'
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
         mask-password: "true"
     - name: Set up Docker Buildx

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -114,7 +114,7 @@ runs:
         fi
     - name: Configure AWS Credentials
       if: steps.push.outputs.push == 'true'
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # 2.2.0
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -48,7 +48,7 @@ runs:
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # 2.2.0
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -63,7 +63,7 @@ runs:
     - name: Login to Amazon ECR
       if: ${{ inputs.aws_registries }}
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
         registries: ${{ inputs.aws_registries }}
       env:

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -25,7 +25,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # 2.2.0
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
         aws-region: ${{ inputs.AWS_REGION }}
         role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -32,7 +32,7 @@ runs:
         role-duration-seconds: 3600
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
         mask-password: "true"
     - name: Set up Docker Buildx

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -36,9 +36,9 @@ runs:
       with:
         mask-password: "true"
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
     - name: Build and Push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
       id: build-image
       with:
         context: .

--- a/docker/image-exists/action.yml
+++ b/docker/image-exists/action.yml
@@ -21,7 +21,7 @@ runs:
   using: composite
   steps:
     - name: Configure AWS Credentials
-      uses: aws-actions/configure-aws-credentials@5fd3084fc36e372ff1fff382a39b10d03659f355 # 2.2.0
+      uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4.0.1
       with:
         aws-region: ${{ inputs.AWS_REGION }}
         role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}

--- a/docker/image-exists/action.yml
+++ b/docker/image-exists/action.yml
@@ -28,7 +28,7 @@ runs:
         role-duration-seconds: 3600
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1
       with:
         mask-password: "true"
     - name: Check if image tag exists


### PR DESCRIPTION
Found some action references which need to be updated so the transitive dependency will use node20 instead of node16.


---

[RE-2021](https://smartcontract-it.atlassian.net/browse/RE-2021)