### PR TITLE
chore: github actions version bumps

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -59,12 +59,13 @@ runs:
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       env:
         GOPRIVATE: ${{ inputs.GOPRIVATE }}
       with:
         go-version-file: "go.mod"
         check-latest: true
+        cache: false
     - name: Replace GHA URL
       shell: bash
       env:

--- a/chainlink-testing-framework/build-tests/action.yml
+++ b/chainlink-testing-framework/build-tests/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     # Setup Tools and libraries
     - name: Setup Go
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.5
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests-binary/action.yml
+++ b/chainlink-testing-framework/run-tests-binary/action.yml
@@ -80,7 +80,7 @@ runs:
   using: composite
   steps:
     - name: Setup Environment
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.5
       with:
         go_necessary: "false"
         cache_restore_only: ${{ inputs.cache_restore_only }}
@@ -133,7 +133,7 @@ runs:
 
     - name: cleanup
       if: always()
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.5
       with:
         triggered_by: ${{ inputs.triggered_by }}
         should_cleanup: ${{ inputs.should_cleanup }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -113,7 +113,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.5
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}
@@ -187,7 +187,7 @@ runs:
 
     - name: cleanup
       if: always()
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@v2.3.5
       with:
         triggered_by: ${{ inputs.triggered_by }}
         should_cleanup: ${{ inputs.should_cleanup }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
+      uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ inputs.go_version }}
         go-version-file: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -37,7 +37,7 @@ runs:
 
     - name: Cache Vendor Packages
       if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
-      uses: actions/cache@v3
+      uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       id: cache-packages
       with:
         path: |
@@ -50,7 +50,7 @@ runs:
 
     - name: Restore Cache Vendor Packages
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
-      uses: actions/cache/restore@v3
+      uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       id: restore-cache-packages
       with:
         path: |

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -28,7 +28,7 @@ runs:
   using: composite
   steps:
     - name: Setup Go
-      uses: actions/setup-go@v4
+    - uses: actions/setup-go@0c52d547c9bc32b1aa3301fd7a9cb496313a4491 # v5.0.0
       with:
         go-version: ${{ inputs.go_version }}
         go-version-file: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -53,7 +53,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.0
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.5
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/helm-version-bump/receiver/action.yml
+++ b/helm-version-bump/receiver/action.yml
@@ -27,7 +27,7 @@ inputs:
       default: ${{ github.token }}
   helm-chart-repo:
     description: |
-      Helm chart repo URL to use, either `sdlc` or `prod`. 
+      Helm chart repo URL to use, either `sdlc` or `prod`.
       Only used if `inputs.helm-chart-repo-update` is true.
       Only use `sdlc` for pre-releases.
 
@@ -111,7 +111,7 @@ runs:
         cmd: yq eval -i '.repositories[] |= select(.name == "infra-charts").url = "${{ inputs.helm-chart-repo }}"' ${{ inputs.app-file-path-pattern }}
     - name: Create PR to deploy
       id: create-pr
-      uses: peter-evans/create-pull-request@284f54f989303d2699d373481a0cfa13ad5a6666 # v5.0.1
+      uses: peter-evans/create-pull-request@b1ddad2c994a25fbc81a28b3ec0e368bb2021c50 # v6.0.0
       with:
         base: ${{ inputs.pr-base-branch }}
         branch: auto/${{ inputs.app-release-name}}/helm-${{ inputs.helm-chart-version }}-${{ inputs.release-type }}


### PR DESCRIPTION
This PR bumps and pins some github actions references:
- `actions/setup-go` from v3/v4 to v5.0.0
	- Explicitly disable caching for the v3 reference as that is the major change from v3 -> v4 (caching enabled by default)
- `actions/cache` and `actions/cache/restore` from v3 to v4.0.0
    - Updates runtime to `node20` 
- `peter-evans/create-pull-request` from v5.0.1 to v6.0.0
    - Updates runtime to `node20` and changes default author

Bump internal references to `v2.3.5` - tag to be created once merged.