### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Node.js 20.x
-        uses: actions/setup-node@v4.0.0
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version: 20.x
       - name: Rebuild the dist/ directory

--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -25,7 +25,7 @@ jobs:
           - directory: ./semver-compare
           - directory: ./go/go-test-results-parsing
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@v4.0.0

--- a/.github/workflows/cleanup-test.yaml
+++ b/.github/workflows/cleanup-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: cleanup with cancel
         if: always()
         id: did_skip

--- a/.github/workflows/go-test-results-parsing-ci.yaml
+++ b/.github/workflows/go-test-results-parsing-ci.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: |
           cd go/go-test-results-parsing
           npm ci
@@ -31,7 +31,7 @@ jobs:
       matrix:
         output-mode: ['unit', 'e2e']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: ./go/go-test-results-parsing
         id: action_run
         continue-on-error: true

--- a/.github/workflows/mod-version-test.yaml
+++ b/.github/workflows/mod-version-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@v4
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Create Test Mod Files
         run: |
           mkdir ./testgood

--- a/.github/workflows/semver-compare-ci.yaml
+++ b/.github/workflows/semver-compare-ci.yaml
@@ -21,13 +21,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - run: npm ci
       - run: npm run all
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - uses: ./semver-compare/
         with:
           version1: 2.0.0

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -131,7 +131,7 @@ runs:
         mask-password: "true"
     - name: Set up Docker Buildx
       if: steps.push.outputs.push == 'true'
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
     - name: Build and Push
       uses: docker/build-push-action@v3
       with:

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -55,7 +55,7 @@ runs:
   steps:
     - name: Checkout Chainlink repo
       if: ${{ inputs.should_checkout == 'true' }}
-      uses: actions/checkout@v3
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       with:
         repository: ${{ inputs.cl_repo }}
         ref: ${{ inputs.cl_ref }}

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -133,7 +133,7 @@ runs:
       if: steps.push.outputs.push == 'true'
       uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
     - name: Build and Push
-      uses: docker/build-push-action@v3
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       with:
         context: .
         file: ${{ inputs.cl_dockerfile }}
@@ -144,3 +144,5 @@ runs:
         tags: ${{ inputs.push_tag }}
         push: ${{ steps.push.outputs.push }}
         secrets: ${{ inputs.docker_secrets }}
+        # enabled by default as of v4 - disable while upgrading action reference (v3 -> v5)
+        provenance: false

--- a/chainlink-testing-framework/build-tests/action.yml
+++ b/chainlink-testing-framework/build-tests/action.yml
@@ -47,7 +47,7 @@ runs:
   steps:
     # Setup Tools and libraries
     - name: Setup Go
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.6
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.7
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests-binary/action.yml
+++ b/chainlink-testing-framework/run-tests-binary/action.yml
@@ -84,7 +84,7 @@ runs:
   using: composite
   steps:
     - name: Setup Environment
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.6
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.7
       with:
         go_necessary: "false"
         cache_restore_only: ${{ inputs.cache_restore_only }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -163,7 +163,7 @@ runs:
 
     # gotestfmt gives us pretty test output
     - name: Set Up gotestfmt
-      uses: GoTestTools/gotestfmt-action@v2
+      uses: GoTestTools/gotestfmt-action@8b4478c7019be847373babde9300210e7de34bfb # v2.2.0
       with:
         token: ${{ inputs.token }} # Avoids rate-limiting
 

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -117,7 +117,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.6
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.7
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -1,4 +1,4 @@
-name: setup-run-tests-environment
+name: setup-go
 description: Common golang setup
 inputs:
   test_download_vendor_packages_command:

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -57,7 +57,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.6
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.7
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -76,7 +76,7 @@ runs:
 
     - name: Set Kubernetes Context
       if: inputs.QA_KUBECONFIG
-      uses: azure/k8s-set-context@v3
+      uses: azure/k8s-set-context@27bfb387305b8f0ab5495d692e4a3304db7d0669 # v4.0.0
       with:
         method: kubeconfig
         kubeconfig: ${{ inputs.QA_KUBECONFIG }}
@@ -100,7 +100,7 @@ runs:
         password: ${{ inputs.dockerhub_password }}
 
     # Helm Setup
-    - uses: azure/setup-helm@v3
+    - uses: azure/setup-helm@29960d0f5f19214b88e1d9ba750a9914ab0f1a2f # v4.0.0
       with:
         version: v3.13.1
     - name: Add required helm charts including chainlink-qa

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -38,7 +38,7 @@ runs:
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
     - name: Build and Push
-      uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
+      uses: docker/build-push-action@4a13e500e55cf31b7a5d59a38ab2040ab0f42f56 # v5.1.0
       id: build-image
       with:
         context: .

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -36,7 +36,7 @@ runs:
       with:
         mask-password: "true"
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226 # v3.0.0
+      uses: docker/setup-buildx-action@0d103c3126aa41d772a8362f6aa67afac040f80c # v3.1.0
     - name: Build and Push
       uses: docker/build-push-action@0565240e2d4ab88bba5387d719585280857ece09 # v5.0.0
       id: build-image


### PR DESCRIPTION
### Changes

External Action Version Bumps:
* bump and pin actions/setup-node to v4.0.2
* bump and pin docker/build-push-action to v5.1.0
  * provenance attestation enabled by default (disabled in workflow)
  * node20 
* bump and pin docker/setup-buildx-action to v3.1.0
  * node20 
* bump and pin references to actions/checkout to v4.1.1
* bump azure setup-helm and k8s-set-context to v4.0.0
  * node20
* bump and pin GoTestTools/gotestfmt-action to v2.2.0
  * node20

Other Changes:
* bump internal action references to v2.3.7
* update setup-go action name
  * the name referenced in the yaml was copied from another action 



