### PR TITLE
chore: grafana internal credentials

### DIFF
--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -20,10 +20,11 @@ jobs:
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2
+        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
         with:
-          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
           this-job-name: Update Version
         continue-on-error: true
 


### PR DESCRIPTION
 ### Changes

Bumping `push-gha-metrics-action` and pass grafana org-id inputs  

### Post-Merge
- [ ] Delete repo `GRAFANA-CLOUD-*` credentials

---

RE-2240