### PR TITLE
chore: bump upload/download artifact action

### DIFF
--- a/chainlink-testing-framework/build-tests/action.yml
+++ b/chainlink-testing-framework/build-tests/action.yml
@@ -88,7 +88,7 @@ runs:
         echo "Built binary at ./integration-tests/tests"
 
     - name: Publish Binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: ${{ inputs.binary_name }}
         path: ./integration-tests/tests

--- a/chainlink-testing-framework/run-tests-binary/action.yml
+++ b/chainlink-testing-framework/run-tests-binary/action.yml
@@ -101,7 +101,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}

--- a/chainlink-testing-framework/run-tests-binary/action.yml
+++ b/chainlink-testing-framework/run-tests-binary/action.yml
@@ -131,7 +131,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -150,7 +150,7 @@ runs:
     # Download any external artifacts
     - name: Download Artifacts
       if: inputs.download_contract_artifacts_path != 'none'
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@c850b930e6ba138125429b7e5c93fc707a7f8427 # v4.1.4
       with:
         name: artifacts
         path: ${{ inputs.download_contract_artifacts_path }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -185,7 +185,7 @@ runs:
 
     - name: Publish Artifacts
       if: failure()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
       with:
         name: ${{ inputs.artifacts_name }}
         path: ${{ inputs.artifacts_location }}


### PR DESCRIPTION
@Tofel found some problems in the [chainlink/Client Compatibility Tests](https://github.com/smartcontractkit/chainlink/actions/runs/8385969928).

These errors are a problem because an artifact was uploaded through `actions/upload-artifact@v3` and trying to be fetched using `actions/download-artifact@v4`.

These versions are incompatible ([source](https://github.blog/changelog/2023-12-14-github-actions-artifacts-v4-is-now-generally-available/)):
> Artifacts v4 is not cross-compatible with previous versions. For example, an artifact uploaded using v3 cannot be used with actions/download-artifact@v4.

I'm bumping the versions here, creating a release, then I will bump the referenced versions in chainlink repository.