### PR TITLE
docs: update readme to point to .github repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# Mono Repo for Reusable Public Chainlink Github Actions
+# [smartcontractkit/.github](https://github.com/smartcontractkit/.github/) is Chainlink's new monorepo for reusable public actions.
+
+The plan is to eventually migrate all actions in this repository to the `.github` repository. Please refrain from making new actions here if possible.
+
+## chainlink-github-actions
 
 Place your action in a logically named folder with the action.yml and README.md and anything else required for your action.
 


### PR DESCRIPTION
Update the README so those looking for reusable actions are also pointed towards the `.github` repository in case they stumble upon this first.