### PR TITLE
Allow to pass go coverage flags to "build chainlink image" and "run test" steps

### DIFF
--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -46,6 +46,10 @@ inputs:
   GOPRIVATE:
     required: false
     description: private repos needed for go
+  COVER_FLAG:
+    required: false
+    default: false
+    description: Build chainlink binary with cover flag
   should_checkout:
     required: false
     description: Do we want to checkout the chainlink code branch, sometimes we don't need to
@@ -145,6 +149,7 @@ runs:
         build-args: |
           COMMIT_SHA=${{ github.sha }}
           CHAINLINK_USER=chainlink
+          COVER_FLAG=${{ inputs.COVER_FLAG }}
         tags: ${{ inputs.push_tag }}
         push: ${{ steps.push.outputs.push }}
         secrets: ${{ inputs.docker_secrets }}

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -46,7 +46,7 @@ inputs:
   GOPRIVATE:
     required: false
     description: private repos needed for go
-  COVER_FLAG:
+  GO_COVER_FLAG:
     required: false
     default: false
     description: Build chainlink binary with cover flag
@@ -149,7 +149,7 @@ runs:
         build-args: |
           COMMIT_SHA=${{ github.sha }}
           CHAINLINK_USER=chainlink
-          COVER_FLAG=${{ inputs.COVER_FLAG }}
+          GO_COVER_FLAG=${{ inputs.GO_COVER_FLAG }}
         tags: ${{ inputs.push_tag }}
         push: ${{ steps.push.outputs.push }}
         secrets: ${{ inputs.docker_secrets }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -61,6 +61,12 @@ inputs:
   go_mod_path:
     required: false
     description: The go.mod file path
+  go_coverage_src_dir:
+    required: false
+    description: The source directory for go coverage files 
+  go_coverage_dest_dir:
+    required: false
+    description: The destination directory to store go coverage files   
   cache_restore_only:
     required: false
     description: Only restore the cache, set to true if you want to restore and save on cache hit miss
@@ -180,6 +186,8 @@ runs:
         CHAINLINK_VERSION: ${{ inputs.cl_image_tag }}
         CHAINLINK_ENV_USER: ${{ github.actor }}
         CGO_ENABLED: ${{ inputs.CGO_ENABLED }}
+        GO_COVERAGE_SRC_DIR: ${{ inputs.go_coverage_src_dir }}
+        GO_COVERAGE_DEST_DIR: ${{ inputs.go_coverage_dest_dir }}
       run: |
         PATH=$PATH:$(go env GOPATH)/bin
         export PATH


### PR DESCRIPTION
This is needed for https://smartcontract-it.atlassian.net/browse/TT-1049 and https://github.com/smartcontractkit/chainlink/pull/12835