### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -48,7 +48,7 @@ jobs:
         id: diff
 
       # If index.js was different than expected, upload the expected version as an artifact
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         if: failure()
         with:
           name: dist

--- a/.github/workflows/check-dist.yaml
+++ b/.github/workflows/check-dist.yaml
@@ -25,7 +25,7 @@ jobs:
           - directory: ./semver-compare
           - directory: ./go/go-test-results-parsing
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Setup Node.js 20.x
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2

--- a/.github/workflows/cleanup-test.yaml
+++ b/.github/workflows/cleanup-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: cleanup with cancel
         if: always()
         id: did_skip

--- a/.github/workflows/go-test-results-parsing-ci.yaml
+++ b/.github/workflows/go-test-results-parsing-ci.yaml
@@ -20,7 +20,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - run: |
           cd go/go-test-results-parsing
           npm ci
@@ -31,7 +31,7 @@ jobs:
       matrix:
         output-mode: ['unit', 'e2e']
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./go/go-test-results-parsing
         id: action_run
         continue-on-error: true

--- a/.github/workflows/mod-version-test.yaml
+++ b/.github/workflows/mod-version-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out Code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - name: Create Test Mod Files
         run: |
           mkdir ./testgood

--- a/.github/workflows/semver-compare-ci.yaml
+++ b/.github/workflows/semver-compare-ci.yaml
@@ -21,13 +21,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - run: npm ci
       - run: npm run all
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: ./semver-compare/
         with:
           version1: 2.0.0

--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -20,8 +20,9 @@ jobs:
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@v2.2.0
+        uses: smartcontractkit/push-gha-metrics-action@dea9b546553cb4ca936607c2267a09c004e4ab3f # v3.0.0
         with:
+          id: sync-github-app-token-issuer
           basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}

--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Get Github Token
         id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
+        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@e29366cdecfe6befff9ab8c3cfe4825218505d58 # v2.3.16
         with:
           url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 

--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -56,7 +56,7 @@ jobs:
         run: ./github-app-token-issuer-buggy/sync.sh
 
       - name: Open PR
-        uses: peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 # v5.0.2
+        uses: peter-evans/create-pull-request@6d6857d36972b65feb161a90e484f2984215f83e # v6.0.5
         with:
           title: Update github-app-token-issuers
           branch: chore/update-github-app-token-issuers

--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -32,7 +32,7 @@ jobs:
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Assume role capable of dispatching action
-        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # 4.0.1
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
         with:
           role-to-assume: ${{ secrets.AWS_OIDC_CHAINLINK_GITHUB_ACTIONS_SYNC_GATI_TOKEN_ISSUER_ROLE_ARN }}
           role-duration-seconds: 3600

--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -29,7 +29,7 @@ jobs:
         continue-on-error: true
 
       - name: Checkout the repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
 
       - name: Assume role capable of dispatching action
         uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # 4.0.1


### PR DESCRIPTION
## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
Workflow:semver-compare-check-dist ---> Job:check-dist ---> actions/upload-artifact@v3 ---> node16
Workflow:Sync github app token issuer code ---> Job:update-version ---> peter-evans/create-pull-request@153407881ec5c347639a548ade7d8ad1d6740e38 ---> node16
```