### PR TITLE
chore: mask aws account id

### DIFF
--- a/.github/workflows/sync-github-app-token-issuer.yaml
+++ b/.github/workflows/sync-github-app-token-issuer.yaml
@@ -39,6 +39,7 @@ jobs:
           role-duration-seconds: 3600
           role-session-name: sync-github-app-token-issuer.update-version
           aws-region: ${{ secrets.AWS_REGION }}
+          mask-aws-account-id: true
 
       - name: Get Github Token
         id: get-gh-token

--- a/chainlink-testing-framework/build-image/action.yml
+++ b/chainlink-testing-framework/build-image/action.yml
@@ -131,6 +131,7 @@ runs:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600
+        mask-aws-account-id: true
     - name: Login to Amazon ECR
       if: steps.push.outputs.push == 'true'
       id: login-ecr

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -78,6 +78,7 @@ runs:
         aws-region: ${{ inputs.QA_AWS_REGION }}
         role-to-assume: ${{ inputs.QA_AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: ${{ inputs.aws_role_duration_seconds }}
+        mask-aws-account-id: true
 
     - name: Set Kubernetes Context
       if: inputs.QA_KUBECONFIG

--- a/docker/build-push/action.yml
+++ b/docker/build-push/action.yml
@@ -30,6 +30,7 @@ runs:
         aws-region: ${{ inputs.AWS_REGION }}
         role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600
+        mask-aws-account-id: true
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1

--- a/docker/image-exists/action.yml
+++ b/docker/image-exists/action.yml
@@ -26,6 +26,7 @@ runs:
         aws-region: ${{ inputs.AWS_REGION }}
         role-to-assume: ${{ inputs.AWS_ROLE_TO_ASSUME }}
         role-duration-seconds: 3600
+        mask-aws-account-id: true
     - name: Login to Amazon ECR
       id: login-ecr
       uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2.0.1


### PR DESCRIPTION
Setting `mask-aws-account-id: true` for all usages of `aws-actions/configure-aws-credentials.

Typically secrets are an ARN which include the account id, but the account id itself won't be masked by default. To minimize leaking them using this flag will also mask the account id.

---

RE-2443
