### PR TITLE
Update chainlink-testing-framework/setup-go and chainlink-testing-framework/run-tests actions

### DIFF
--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -206,7 +206,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@4caeda4dab4c982bccd5650b6084ddeb7a93f24a # v2.3.30
+      uses: ./chainlink-testing-framework/setup-run-tests-environment
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -203,6 +203,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check out Code
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -214,7 +214,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@75a6c77c7132bd92b05dd103da06e67ac9dae6e7 # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@e4dd107855e2359e2d762a48872a3e9365e70f11 # v2.3.30
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -203,13 +203,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check out Code
-      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: ./chainlink-testing-framework/setup-run-tests-environment
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@339a3ac3dc60864a037fb9132f072c7ddcfc2e9f # v2.3.30
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -206,7 +206,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@339a3ac3dc60864a037fb9132f072c7ddcfc2e9f # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@993454cbeedac2ee60fa37854614b521b51f0d26 # v2.3.30
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -206,7 +206,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.3.20
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@4caeda4dab4c982bccd5650b6084ddeb7a93f24a # v2.3.30
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -203,6 +203,14 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Checkout chainlink-testing-framework to use citool
+      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      with:
+        repository: smartcontractkit/chainlink-testing-framework
+        ref: main
+        fetch-depth: 0
+        path: ctf
+
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
@@ -327,14 +335,6 @@ runs:
       if: inputs.test_secrets_override_base64 != ''
       shell: bash
       run: go run ${{ github.action_path }}/mask-testsecrets/main.go "${{ inputs.test_secrets_override_base64 }}"
-
-    - name: Checkout chainlink-testing-framework to use citool
-      uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      with:
-        repository: smartcontractkit/chainlink-testing-framework
-        ref: main
-        fetch-depth: 0
-        path: ctf
 
     - name: Create default test config override
       if: inputs.test_config_override_base64 == ''

--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -214,7 +214,7 @@ runs:
     # Setup Tools and libraries
     - name: Setup environment
       if: inputs.run_setup == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@993454cbeedac2ee60fa37854614b521b51f0d26 # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@75a6c77c7132bd92b05dd103da06e67ac9dae6e7 # v2.3.30
       with:
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -15,7 +15,7 @@ inputs:
   cache_builds:
     required: false
     description: Cache go builds
-    default: "true"
+    default: "false"
   cache_version: 
     description: Set this to cache bust
     default: "1"    
@@ -51,21 +51,16 @@ runs:
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       id: cache-packages
       with:
-        path: |
-          ${{ steps.go-cache-dir.outputs.gomodcache }}
-          ~/go/pkg/mod
-          ~/go/bin
+        path: ${{ steps.go-cache-dir.outputs.gomodcache }}
         key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache_version }}-
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-      if: ${{ inputs.cache_builds == 'true' }}
-      name: Cache Go Build Outputs
+      if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
+      name: Cache Go Builds
       with:
-        path: |
-          ~/.cache/go-build
-          ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
         key: ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
@@ -79,8 +74,6 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
-          ~/go/pkg/mod
-          ~/go/bin
         key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
           ${{ runner.os }}-gomod-${{ inputs.cache_version }}-

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -20,9 +20,9 @@ inputs:
     required: false
     description: Cache go builds
     default: "true"
-  cache_key_id:
-    required: true
-    description: Cache go vendors unique id
+  cache_version: 
+    description: Set this to cache bust
+    default: "1"    
   no_cache:
     required: false
     description: Do not use a go cache
@@ -59,9 +59,9 @@ runs:
           ${{ steps.go-cache-dir.outputs.gomodcache }}
           ~/go/pkg/mod
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-
+          ${{ runner.os }}-gomod-${{ inputs.cache_version }}-
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: ${{ inputs.cache_builds == 'true' }}
@@ -71,10 +71,10 @@ runs:
           ~/.cache/go-build
           ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go_mod_path) }}-
-          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
+          ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}-
+          ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
@@ -82,11 +82,12 @@ runs:
       id: restore-cache-packages
       with:
         path: |
+          ${{ steps.go-cache-dir.outputs.gomodcache }}
           ~/go/pkg/mod
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-
+          ${{ runner.os }}-gomod-${{ inputs.cache_version }}-
 
     - name: Tidy and check files
       if: ${{ inputs.should_tidy == 'true' }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -19,9 +19,6 @@ inputs:
   cache_key_id:
     required: true
     description: Cache key id
-  cache_version: 
-    description: Set this to cache bust
-    default: "1"    
   no_cache:
     required: false
     description: Do not use a go cache
@@ -59,9 +56,9 @@ runs:
       id: cache-packages
       with:
         path: ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
@@ -69,9 +66,9 @@ runs:
       with:
         path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gobuild-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gobuild-
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gobuild-
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
@@ -80,9 +77,9 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-gomod-
 
     - name: Tidy and check files
       if: ${{ inputs.should_tidy == 'true' }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -16,6 +16,10 @@ inputs:
     required: false
     description: Only restore the cache, set to true if you want to restore and save on cache hit miss
     default: "false"
+  cache_builds:
+    required: false
+    description: Cache go builds
+    default: "true"
   cache_key_id:
     required: true
     description: Cache go vendors unique id
@@ -39,29 +43,48 @@ runs:
         check-latest: true
         cache: false
 
-    - name: Cache Vendor Packages
+    - name: Set go cache keys
+      shell: bash
+      id: go-cache-dir
+      run: |
+        echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT
+        echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT        
+
+    - name: Cache Go Modules
       if: inputs.cache_restore_only == 'false' && inputs.no_cache == 'false'
       uses: actions/cache@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       id: cache-packages
       with:
         path: |
-          ~/.cache/go-build
+          ${{ steps.go-cache-dir.outputs.gomodcache }}
           ~/go/pkg/mod
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache_key_id }}-
 
-    - name: Restore Cache Vendor Packages
+    - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      if: ${{ inputs.cache_builds == 'true' }}
+      name: Cache Go Build Outputs
+      with:
+        path: |
+          ~/.cache/go-build
+          ${{ steps.go-cache-dir.outputs.gobuildcache }}
+        # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
+        key: ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-${{ hashFiles(inputs.go_mod_path) }}-
+          ${{ runner.os }}-gobuild-${{ inputs.cache-version }}-
+
+    - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
       uses: actions/cache/restore@13aacd865c20de90d75de3b17ebe84f7a17d57d2 # v4.0.0
       id: restore-cache-packages
       with:
         path: |
-          ~/.cache/go-build
           ~/go/pkg/mod
           ~/go/bin
-        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
           ${{ runner.os }}-${{ inputs.cache_key_id }}-
 

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -16,6 +16,9 @@ inputs:
     required: false
     description: Cache go builds
     default: "false"
+  cache_key_id:
+    required: true
+    description: Cache key id
   cache_version: 
     description: Set this to cache bust
     default: "1"    
@@ -52,9 +55,9 @@ runs:
       id: cache-packages
       with:
         path: ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache_version }}-
+          ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
@@ -62,10 +65,8 @@ runs:
       with:
         path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
-        restore-keys: |
-          ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}-
-          ${{ runner.os }}-gobuild-${{ inputs.cache_version }}-
+        key: ${{ runner.os }}-gobuild-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
+          ${{ runner.os }}-gobuild-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
@@ -74,9 +75,9 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-gomod-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache_version }}-
+          ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
 
     - name: Tidy and check files
       if: ${{ inputs.should_tidy == 'true' }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -30,7 +30,6 @@ inputs:
   test_download_vendor_packages_command:
     required: false
     description: The command to download the go modules
-    default: make download    
 
 runs:
   using: composite
@@ -88,5 +87,6 @@ runs:
         go_mod_path: ${{ inputs.go_mod_path }}
 
     - name: Run go mod download
+      if: inputs.test_download_vendor_packages_command
       shell: bash
       run: ${{ inputs.test_download_vendor_packages_command }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -55,9 +55,9 @@ runs:
       id: cache-packages
       with:
         path: ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-
 
     - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
       if: inputs.cache_restore_only == 'false' && inputs.cache_builds == 'true'
@@ -65,8 +65,9 @@ runs:
       with:
         path: ${{ steps.go-cache-dir.outputs.gobuildcache }}
         # The lifetime of go build outputs is pretty short, so we make our primary cache key be the branch name
-        key: ${{ runner.os }}-gobuild-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
-          ${{ runner.os }}-gobuild-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gobuild-${{ hashFiles(inputs.go_mod_path) }}
+        restore-keys: |
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gobuild-
 
     - name: Restore Go Modules
       if: inputs.cache_restore_only != 'false' && inputs.no_cache == 'false'
@@ -75,9 +76,9 @@ runs:
       with:
         path: |
           ${{ steps.go-cache-dir.outputs.gomodcache }}
-        key: ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-${{ hashFiles(inputs.go_mod_path) }}
+        key: ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-${{ hashFiles(inputs.go_mod_path) }}
         restore-keys: |
-          ${{ runner.os }}-gomod-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-
+          ${{ runner.os }}-${{ inputs.cache_key_id }}-${{ inputs.cache_version }}-gomod-
 
     - name: Tidy and check files
       if: ${{ inputs.should_tidy == 'true' }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -1,10 +1,6 @@
 name: setup-go
 description: Common golang setup
 inputs:
-  test_download_vendor_packages_command:
-    required: false
-    description: The command to download the go modules
-    default: make download
   go_version:
     required: false
     description: Go version to install
@@ -94,7 +90,3 @@ runs:
       uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/go-mod-tidy@v2.3.6
       with:
         go_mod_path: ${{ inputs.go_mod_path }}
-
-    - name: Download Go Vendor Packages
-      shell: bash
-      run: ${{ inputs.test_download_vendor_packages_command }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -30,6 +30,10 @@ inputs:
     required: false
     description: Should we check go mod tidy
     default: "true"
+  test_download_vendor_packages_command:
+    required: false
+    description: The command to download the go modules
+    default: make download    
 
 runs:
   using: composite
@@ -85,3 +89,7 @@ runs:
       uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/go-mod-tidy@v2.3.6
       with:
         go_mod_path: ${{ inputs.go_mod_path }}
+
+    - name: Run go mod download
+      shell: bash
+      run: ${{ inputs.test_download_vendor_packages_command }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -61,7 +61,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@339a3ac3dc60864a037fb9132f072c7ddcfc2e9f # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@993454cbeedac2ee60fa37854614b521b51f0d26 # v2.3.30
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -69,6 +69,7 @@ runs:
         cache_key_id: ${{ inputs.cache_key_id }}
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
+        test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -61,7 +61,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@993454cbeedac2ee60fa37854614b521b51f0d26 # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@75a6c77c7132bd92b05dd103da06e67ac9dae6e7 # v2.3.30
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -61,7 +61,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@75a6c77c7132bd92b05dd103da06e67ac9dae6e7 # v2.3.30
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@e4dd107855e2359e2d762a48872a3e9365e70f11 # v2.3.30
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -58,6 +58,9 @@ inputs:
 runs:
   using: composite
   steps:
+    - name: Check out Code
+      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -61,7 +61,7 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@4caeda4dab4c982bccd5650b6084ddeb7a93f24a # v2.3.30
+      uses: ./chainlink-testing-framework/setup-go
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -61,9 +61,8 @@ runs:
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@v2.3.14
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@4caeda4dab4c982bccd5650b6084ddeb7a93f24a # v2.3.30
       with:
-        test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}
         cache_restore_only: ${{ inputs.cache_restore_only }}

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -58,13 +58,10 @@ inputs:
 runs:
   using: composite
   steps:
-    - name: Check out Code
-      uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-        
     # Go setup and caching
     - name: Setup Go
       if: inputs.go_necessary == 'true'
-      uses: ./chainlink-testing-framework/setup-go
+      uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@339a3ac3dc60864a037fb9132f072c7ddcfc2e9f # v2.3.30
       with:
         go_version: ${{ inputs.go_version }}
         go_mod_path: ${{ inputs.go_mod_path }}


### PR DESCRIPTION
- Add `cache_builds` input to optionally cache golang builds based on `go env GOCACHE` 
- Use `go env GOMODCACHE` to cache golang mods
- Clean up order of inputs and actions