### PR TITLE
Adding step to use GATI Token in pulling private repos 

### DIFF
--- a/chainlink-testing-framework/run-tests/action.yml
+++ b/chainlink-testing-framework/run-tests/action.yml
@@ -79,6 +79,9 @@ inputs:
     required: false
     description: The check name for publishing the reports
     default: Smoke Test Results
+  gati_token:
+    required: false
+    description: Token provided by GATI to pull from private repos
   token:
     required: false
     description: The GITHUB_TOKEN for the workflow
@@ -230,6 +233,7 @@ runs:
         QA_KUBECONFIG: ${{ inputs.QA_KUBECONFIG }}
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
+        gati_token: ${{ inputs.gati_token }}
 
     - name: Replace chainlink/integration-tests deps
       if: ${{ inputs.dep_chainlink_integration_tests }}

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -44,11 +44,11 @@ runs:
         go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false
-    - name: Setup git config for private repo access
-      if: inputs.github_token
+    - name: Setup Go with private repo access
       shell: bash
-      run: git config --global url."https://x-access-token:${{ inputs.gati_token }}@github.com/".insteadOf "https://github.com/" && \
-        go env -w GOPRIVATE=github.com/smartcontractkit/* 
+      run: |
+        git config --global url."https://x-access-token:${{ inputs.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+        go env -w GOPRIVATE=github.com/smartcontractkit/*
     - name: Set go cache keys
       shell: bash
       id: go-cache-dir

--- a/chainlink-testing-framework/setup-go/action.yml
+++ b/chainlink-testing-framework/setup-go/action.yml
@@ -30,6 +30,9 @@ inputs:
   test_download_vendor_packages_command:
     required: false
     description: The command to download the go modules
+  gati_token:
+    required: false
+    description: GATI token used to pull private repos
 
 runs:
   using: composite
@@ -41,7 +44,11 @@ runs:
         go-version-file: ${{ inputs.go_mod_path }}
         check-latest: true
         cache: false
-
+    - name: Setup git config for private repo access
+      if: inputs.github_token
+      shell: bash
+      run: git config --global url."https://x-access-token:${{ inputs.gati_token }}@github.com/".insteadOf "https://github.com/" && \
+        go env -w GOPRIVATE=github.com/smartcontractkit/* 
     - name: Set go cache keys
       shell: bash
       id: go-cache-dir

--- a/chainlink-testing-framework/setup-run-tests-environment/action.yml
+++ b/chainlink-testing-framework/setup-run-tests-environment/action.yml
@@ -54,6 +54,9 @@ inputs:
     required: false
     description: Do not use a go cache
     default: "false"
+  gati_token:
+    required: false
+    description: Token provided by GATI to pull from private repos
 
 runs:
   using: composite
@@ -70,6 +73,7 @@ runs:
         should_tidy: ${{ inputs.should_tidy }}
         no_cache: ${{ inputs.no_cache }}
         test_download_vendor_packages_command: ${{ inputs.test_download_vendor_packages_command }}
+        gati_token: ${{ gati_token }}
 
     # Setup AWS cred and K8s context
     - name: Configure AWS Credentials


### PR DESCRIPTION
### Description
We have a repository ([chainlink-starknet](https://github.com/smartcontractkit/chainlink-starknet/tree/develop)) that uses [chainlink-testing-framework](https://github.com/smartcontractkit/chainlink-starknet/blob/develop/.github/workflows/integration-tests-smoke.yml#L187) to run it's integration tests. We recently added a dependency on [guauntlet-plus-plus](https://github.com/smartcontractkit/gauntlet-plus-plus) which is a private repo. This is causing our Github CI/CD steps to [fail](https://github.com/smartcontractkit/chainlink-starknet/actions/runs/11859007343/job/33051597179?pr=548) on the step that uses the [chainlink-testing-framework image](https://github.com/smartcontractkit/chainlink-starknet/blob/develop/.github/workflows/integration-tests-smoke.yml#L187). More specifically its failing on the [setup-go step](https://github.com/smartcontractkit/chainlink-github-actions/blob/v2.3.31/chainlink-testing-framework/run-tests/action.yml#L215) where it runs [Tidy and check files](https://github.com/smartcontractkit/chainlink-github-actions/blob/v2.3.31/chainlink-testing-framework/setup-go/action.yml#L83), since the workflow can't pull the private repo when running `go mod tidy`

After talking with the infra team they advised to use [GATI](https://smartcontract-it.atlassian.net/wiki/spaces/RE/pages/696909854/Github+App+Token+Issuer+GATI+-+Self+Service+Guide) while [setting git configs](https://chainlink-core.slack.com/archives/C038Q8K1HTR/p1731016579870599) in order to pull from private repos

### Changes
- Added an extra step that takes in an optional GATI Token that sets git configs before running `go mod tidy`
- Step runs on an if so it's backwards compatible 
